### PR TITLE
Vendored can't works for hdfs

### DIFF
--- a/hdfs-sys/build.rs
+++ b/hdfs-sys/build.rs
@@ -63,13 +63,23 @@ fn without_hadoop_home() -> Result<()> {
     builder.file(format!("{hadoop_src}/hdfs.c"));
     builder.file(format!("{hadoop_src}/jni_helper.c"));
     builder.file(format!("{hadoop_src}/jclasses.c"));
+    if cfg!(windows) {
+        builder.file(format!("{hadoop_src}/os/windows/mutexes.c"));
+        builder.file(format!("{hadoop_src}/os/windows/thread.c"));
+        builder.file(format!("{hadoop_src}/os/windows/thread_local_storage.c"));
+    } else {
+        builder.file(format!("{hadoop_src}/os/posix/mutexes.c"));
+        builder.file(format!("{hadoop_src}/os/posix/thread.c"));
+        builder.file(format!("{hadoop_src}/os/posix/thread_local_storage.c"));
+    }
 
     // Ignore all warnings from libhdfs.
     builder.warnings(false);
+    // builder.static_flag(true);
     // Compile
     builder.compile("hdfs");
 
-    println!("cargo:rustc-link-lib=hdfs");
+    println!("cargo:rustc-link-lib=static=hdfs");
 
     let bindings = bindgen::Builder::default()
         .header(format!("{hadoop_src}/include/hdfs/hdfs.h"))

--- a/hdrs/Cargo.toml
+++ b/hdrs/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.0.0"
 
 [dependencies]
 anyhow = "1.0.57"
-hdfs-sys = "0.0.1"
+hdfs-sys = { path = "../hdfs-sys" }
 libc = "0.2.124"
 log = "0.4.16"
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

---

We can't vendor hdfs as we must use the same version of jar and `libhdfs.so`.