### PR TITLE
fix: Hadoop 2.2 doesn't handle FileNotFound error correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ tokio-io = ["tokio"]
 
 [dependencies]
 futures-io = { version = "0.3.21", optional = true }
-hdfs-sys = "0.2.0"
+# hdrs requires at least hadoop 2.3 to work.
+# hadoop 2.2 doesn't handle FileNotFound correctly.
+hdfs-sys = { version = "0.2.0", features = ["hdfs_2_3"] }
 libc = "0.2.124"
 log = "0.4.16"
 tokio = { version = "1.18.0", optional = true }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -82,6 +82,17 @@ fn test_file() -> Result<()> {
     }
 
     {
+        // Read not exist file
+        debug!("test not exist file read");
+        let mut f = fs
+            .open_file()
+            .read(true)
+            .open(&format!("{work_dir}{}", uuid::Uuid::new_v4()));
+        assert!(f.is_err());
+        assert_eq!(f.unwrap_err().kind(), io::ErrorKind::NotFound)
+    }
+
+    {
         // Stat file.
         debug!("test file stat");
         let fi = fs.metadata(&path)?;


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>