### PR TITLE
fix: read/write large file (>2GB)

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -10,6 +10,9 @@ use hdfs_sys::*;
 use libc::c_void;
 use log::debug;
 
+// at most 2^30 bytes, ~1GB
+const FILE_LIMIT: i32 = 1073741824;
+
 /// Options and flags which can be used to configure how a file is opened.
 ///
 /// This builder exposes the ability to configure how a [`File`] is opened and
@@ -384,8 +387,7 @@ impl Read for File {
                 self.fs,
                 self.f,
                 buf.as_ptr() as *mut c_void,
-                // at most 2^30 bytes, ~1GB
-                buf.len().min(1073741824) as i32,
+                (buf.len() as i32).min(FILE_LIMIT),
             )
         };
 
@@ -422,8 +424,7 @@ impl Write for File {
                 self.fs,
                 self.f,
                 buf.as_ptr() as *const c_void,
-                // at most 2^30 bytes, ~1GB
-                buf.len().min(1073741824) as i32,
+                (buf.len() as i32).min(FILE_LIMIT),
             )
         };
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -384,7 +384,8 @@ impl Read for File {
                 self.fs,
                 self.f,
                 buf.as_ptr() as *mut c_void,
-                buf.len() as i32,
+                // at most 2^30 bytes, ~1GB
+                buf.len().min(1073741824) as i32,
             )
         };
 
@@ -421,7 +422,8 @@ impl Write for File {
                 self.fs,
                 self.f,
                 buf.as_ptr() as *const c_void,
-                buf.len() as i32,
+                // at most 2^30 bytes, ~1GB
+                buf.len().min(1073741824) as i32,
             )
         };
 


### PR DESCRIPTION
`hdrs` raises a critical error when reading/writing a large file to hdfs. This is due to the length limit of a single `hdfsRead` call. I tested with a file of 40G, but I think any file that is larger than 2GB will face the same issue. 

The [length parameter](https://github.com/Xuanwo/hdfs-sys/blob/main/src/hdfs_2_2.rs#L112) requires an i32, which is at most 2^31-1. Though I have tried that length size and only get an out of memory error. Thus I think it safer to limit the length to 2^30 bytes. 

This patch is inspired by the rust underlying implementation of [`Write`](https://github.com/rust-lang/rust/blob/3fdd578d72a24d4efc2fe2ad18eec3b6ba72271e/library/std/src/sys/unix/fd.rs#L155) to [`File`](https://doc.rust-lang.org/std/fs/struct.File.html).

After this patch, it's advisable to use [`write_all`](https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all) instead of [`write`](https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write), and `read_to_end` instead of `read`.