### PR TITLE
fix: buffer size overflow when reading/writing a large file(>2G)

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -11,7 +11,7 @@ use libc::c_void;
 use log::debug;
 
 // at most 2^30 bytes, ~1GB
-const FILE_LIMIT: i32 = 1073741824;
+const FILE_LIMIT: usize = 1073741824;
 
 /// Options and flags which can be used to configure how a file is opened.
 ///
@@ -387,7 +387,7 @@ impl Read for File {
                 self.fs,
                 self.f,
                 buf.as_ptr() as *mut c_void,
-                (buf.len() as i32).min(FILE_LIMIT),
+                buf.len().min(FILE_LIMIT) as i32,
             )
         };
 
@@ -424,7 +424,7 @@ impl Write for File {
                 self.fs,
                 self.f,
                 buf.as_ptr() as *const c_void,
-                (buf.len() as i32).min(FILE_LIMIT),
+                buf.len().min(FILE_LIMIT) as i32,
             )
         };
 


### PR DESCRIPTION
When reading/writing a large file (>2G), `hdrs` casts a invalid input error. 

The previous implementation first cast a usize to i32 like `(buf.len() as i32).min(FILE_LIMIT)`, and it cause overflow here when usize is large (>2G).

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }'
```

I test the patched version this time, and it finally works.