### PR TITLE
fix: `ClientBuilder` auth info drop before connect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
         env:
           LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.HADOOP_HOME }}/lib/native
           HDRS_TEST: on
+          HDRS_INTEGRATED_TEST: on
           HDRS_NAMENODE: hdfs://localhost:8020
           HDRS_WORKDIR: /tmp/hdrs/
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -370,7 +370,7 @@ fn test_client_with_user() -> Result<()> {
     let _ = env_logger::try_init();
 
     dotenv::from_filename(".env").ok();
-    if std::env::var("HDRS_TEST").unwrap_or_default() != "on" {
+    if std::env::var("HDRS_INTEGRATED_TEST").unwrap_or_default() != "on" {
         return Ok(());
     }
     let name_node = env::var("HDRS_NAMENODE")?;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -364,3 +364,26 @@ async fn test_futures_file() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_client_with_user() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    dotenv::from_filename(".env").ok();
+    if std::env::var("HDRS_TEST").unwrap_or_default() != "on" {
+        return Ok(());
+    }
+    let name_node = env::var("HDRS_NAMENODE")?;
+    let work_dir = env::var("HDRS_WORKDIR").unwrap_or_default();
+
+    let fs = ClientBuilder::new(&name_node)
+        .with_user("test_user")
+        .connect()?;
+    let test_dir = format!("{}/test_dir", work_dir);
+    let _ = fs.create_dir(&test_dir);
+    let meta = fs.metadata(&test_dir);
+    assert!(meta.is_ok());
+    assert_eq!(meta.unwrap().owner(), "test_user");
+
+    Ok(())
+}


### PR DESCRIPTION
# Issue description
The `ClientBuilder` is not properly tested and contains a severe memory leak issue.

The bugyy code is show below:
```rust
let fs = unsafe {
    let builder = hdfsNewBuilder();

    let name_node = CString::new(self.name_node.as_bytes())?;
    hdfsBuilderSetNameNode(builder, name_node.as_ptr());

    if let Some(v) = self.user {
        let user = CString::new(v.as_bytes())?;
        hdfsBuilderSetUserName(builder, user.as_ptr());  // DANGLING POINTER
        // user is dropped here, but hdfsBuilder still holds a pointer to it
    }

    if let Some(v) = self.kerberos_ticket_cache_path {
        let ticket_cache_path = CString::new(v.as_bytes())?;
        hdfsBuilderSetKerbTicketCachePath(builder, ticket_cache_path.as_ptr()); // DANGLING POINTER
        // ticket_cache_path is dropped here, but hdfsBuilder still holds a pointer to it
    }
   
    // now the user and ticket_cache_path are used to setup auth, but the underlying CString is already freed
    hdfsBuilderConnect(builder)
};
```
# Solution
The solution is to declare a variable that lives until where `hdfsBuilderConnect` is called. Here I use `MaybeUninit` to hold the `user` and `ticket_cache_path` string when necessary. This raises (maybe or not) MSRV to 1.36.0, which is released in fall 2019.

## What this PR does
- fix `ClientBuilder::connect` memory leak issue, properly set user and ticket_cache_path
- add a unit test to validate user declaration